### PR TITLE
[Init]店舗登録画面初期化

### DIFF
--- a/src/app/redirect/page.tsx
+++ b/src/app/redirect/page.tsx
@@ -46,8 +46,14 @@ export default function RedirectPage() {
 					removeCookie('user_id');
 					removeCookie('token');
 					router.push('/login');
+				} else if(response['is_new_user']) {
+					// 新規ユーザの場合は店舗作成画面へ遷移
+					setCookie('user_id', response['user_id']);
+					setCookie('token', response['token']);
+
+					router.push('/store/create');
 				} else {
-					// 認証情報をCookieに保存
+					// 既存ユーザの場合はホーム画面へ遷移
 					setCookie('user_id', response['user_id']);
 					setCookie('token', response['token']);
 

--- a/src/app/store/create/page.tsx
+++ b/src/app/store/create/page.tsx
@@ -5,21 +5,27 @@ import SubmitButton from '@/features/store/components/SubmitButton'
 import Link from 'next/link'
 import CreateStore from '@/features/store/api/CreateStore'
 import { StoreCreateProps } from '@/features/store/types'
+import { useRouter } from 'next/navigation'
+import { useCookies } from 'react-cookie'
 
 export default function StoreCreate() {
 	const [storeName, setStoreName] = useState('');
+	const [cookies] = useCookies(['token']);
+	const router = useRouter();
 
 	const handleSubmit = async (e: any) => {
 		e.preventDefault();
-		const res: StoreCreateProps = await CreateStore({
+
+		const response: StoreCreateProps = await CreateStore({
 			storeName: storeName,
 			location: "日本",
+			token: cookies.token
 		});
-		console.log("resです",res);
-		if (res['response']) {
-			alert(res['response']);
+
+		if (response['response']) {
+			router.push('/home');
 		} else {
-			alert(res['error']);
+			alert(response['error']);
 		}
 	}
 

--- a/src/app/store/create/page.tsx
+++ b/src/app/store/create/page.tsx
@@ -1,0 +1,44 @@
+"use client"
+import { useState } from 'react'
+import TextBox from '@/features/store/components/TextBox'
+import SubmitButton from '@/features/store/components/SubmitButton'
+import Link from 'next/link'
+import CreateStore from '@/features/store/api/CreateStore'
+import { StoreCreateProps } from '@/features/store/types'
+
+export default function StoreCreate() {
+	const [storeName, setStoreName] = useState('');
+
+	const handleSubmit = async (e: any) => {
+		e.preventDefault();
+		const res: StoreCreateProps = await CreateStore({
+			storeName: storeName,
+			location: "日本",
+		});
+		console.log("resです",res);
+		if (res['response']) {
+			alert(res['response']);
+		} else {
+			alert(res['error']);
+		}
+	}
+
+	return (
+		<>
+			<div className="text-center w-fit mx-auto">
+				<div>
+					<h1 className="text-4xl font-bold m-10">グループを新規作成</h1>
+					<TextBox name={'店舗名を入力'} setStoreName={setStoreName} />
+					<div className="flex justify-end my-10">
+						<SubmitButton name={'作成'} onClick={handleSubmit} />
+					</div>
+				</div>
+				<div>
+					<Link href={"/store/join"}>
+						<span className="text-blue-800">グループに参加</span>
+					</Link>
+				</div>
+			</div>
+		</>
+	);
+};

--- a/src/features/store/api/CreateStore.ts
+++ b/src/features/store/api/CreateStore.ts
@@ -1,0 +1,23 @@
+const CreateStore = async ({ storeName }: { storeName: string, location: string }) => {
+	let res: any;
+	await fetch(process.env.NEXT_PUBLIC_API_URL + '/store/create', {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify({
+			store_name: storeName,
+			location: location,
+		}),
+	})
+	.then((response) => response.json())
+	.then((data) => {
+		res = data;
+	})
+	.catch((error) => {
+		res = error;
+	});
+	return res;
+};
+
+export default CreateStore;

--- a/src/features/store/api/CreateStore.ts
+++ b/src/features/store/api/CreateStore.ts
@@ -1,9 +1,10 @@
-const CreateStore = async ({ storeName }: { storeName: string, location: string }) => {
-	let res: any;
+const CreateStore = async ({ storeName, location, token }: { storeName: string, location: string, token?: string }) => {
+	let response: any;
 	await fetch(process.env.NEXT_PUBLIC_API_URL + '/store/create', {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/json',
+			'Authorization': 'Bearer ' + token
 		},
 		body: JSON.stringify({
 			store_name: storeName,
@@ -12,12 +13,12 @@ const CreateStore = async ({ storeName }: { storeName: string, location: string 
 	})
 	.then((response) => response.json())
 	.then((data) => {
-		res = data;
+		response = data;
 	})
 	.catch((error) => {
-		res = error;
+		response = error;
 	});
-	return res;
+	return response;
 };
 
 export default CreateStore;

--- a/src/features/store/components/SubmitButton.tsx
+++ b/src/features/store/components/SubmitButton.tsx
@@ -1,0 +1,13 @@
+import { SubmitButtonProps } from "../types";
+
+const SubmitButton: React.FC<SubmitButtonProps> = ({ onClick, name }) => {
+	return (
+		<button onClick={onClick} className="inline-flex justify-center rounded-lg text-sm font-semibold py-2.5 px-4 bg-slate-900 text-white hover:bg-slate-700 -my-2.5">
+			<span>
+				{name}
+			</span>
+		</button>
+	);
+}
+
+export default SubmitButton;

--- a/src/features/store/components/TextBox.tsx
+++ b/src/features/store/components/TextBox.tsx
@@ -1,0 +1,30 @@
+"use client"
+import React, { useState } from "react";
+import "../style/style.css";
+import { TextBoxProps } from "../types";
+
+export default function TextBox({ name, setStoreName }: TextBoxProps) {
+	const [isFocused, setIsFocused] = useState(false);
+	const borderColor = isFocused ? '#0b57d0' : '#1f1f1f';
+
+	return (
+		<div className="text_box" style={{
+			borderTopColor: borderColor,
+			borderLeftColor: borderColor,
+			borderRightColor: borderColor,
+			borderBottomColor: borderColor,
+			transition: 'border-color 200ms ease-in-out'
+		}}>
+			<div className="text_inner">
+				<input
+					id="new_group"
+					type="text"
+					onChange={(e) => setStoreName(e.target.value)}
+					onFocus={() => setIsFocused(true)}
+					onBlur={() => setIsFocused(false)}
+				/>
+				<div className="text_string">{name}</div>
+			</div>
+		</div>
+	);
+};

--- a/src/features/store/style/style.css
+++ b/src/features/store/style/style.css
@@ -1,0 +1,76 @@
+/**
+ * 店舗作成ページ
+ */
+.input-group {
+	height: 28px;
+	margin: 1px 1px 0 1px;
+	padding: 13px 15px;
+	width: 100%;
+	z-index: 1;
+}
+
+.text_box {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 100%;
+	height: 50px;
+	border-radius: 5px;
+	border: 1px solid #1f1f1f;
+	margin-bottom: 10px;
+}
+
+.text_inner {
+	width: 100%;
+	height: 100%;
+	background-color: transparent;
+	position: relative;
+}
+
+#new_group {
+	position: absolute;
+	z-index: 1;
+	height: 100%;
+	width: 100%;
+	top: 0;
+	left: 0;
+	bottom: 0;
+	right: 0;
+	border: none;
+	outline: none;
+	padding: 0 10px;
+	font-size: 16px;
+	background-color: transparent;
+	box-sizing: border-box;
+}
+
+.text_string {
+	position: absolute;
+	height: 100%;
+	width: 140px;
+	top: 0;
+	left: 0;
+	bottom: 0;
+	right: 0;
+	font-size: 16px;
+	line-height: 50px;
+	background-color: transparent;
+	color: #1f1f1f;
+	box-sizing: border-box;
+	transition: all 0.2s;
+	-webkit-transition: all 0.2s;
+	z-index: 10;
+}
+
+/* placeholderアニメーション */
+#new_group:focus+.text_string,
+#new_group:not(:placeholder-shown)+.text_string {
+	color: #0b57d0;
+	font-size: 10px;
+	line-height: 10px;
+	width: 85px;
+	height: 10px;
+	padding: 0 2px;
+	background-color: white;
+	transform: translate3d(5px, -6px, 0);
+}

--- a/src/features/store/types/index.ts
+++ b/src/features/store/types/index.ts
@@ -1,0 +1,14 @@
+export interface SubmitButtonProps {
+	onClick: (e: any) => Promise<void>;
+	name: string;
+}
+
+export interface TextBoxProps {
+	name: string;
+	setStoreName: React.Dispatch<React.SetStateAction<string>>;
+}
+
+export interface StoreCreateProps {
+	response?: object;
+	error?: object;
+}


### PR DESCRIPTION
## 概要
店舗登録画面を作成しました．

## 変更点
- ログイン後，店舗登録画面にて店舗を作成する画面を追加
- `/store/create`のパスを追加
- ボタンとテキスト入力ボックスをコンポーネント化
- 新規ユーザと既存ユーザで遷移先の分岐追加

## 影響範囲
- ログイン処理後，招待されていない新規ユーザは`/store/create`で店舗登録画面に遷移

## テスト
- 店舗名入力後，アラートで以下のメッセージを確認
    - 1文字以上の店舗名を入力すると，登録完了メッセージ
    - 空文字若しくはすでに登録されている店舗名を入力すると，登録失敗メッセージ

## 関連Issue
- グループ参加画面追加: #1 

## 備考
- 店舗参加処理は別途作成する