### PR TITLE
[Add]スタッフのシフト一覧表示

### DIFF
--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,17 +1,22 @@
 "use client"
 import React, { useState, useContext } from "react";
 import Link from "next/link";
+import RegisterDraftShiftsButton from "@/features/home/calendar/components/draftShift/RegisterDraftShiftsButton";
 import { WeekAxisCalendar } from "@/features/home/calendar/components/weekAxis/WeekAxisCalendar";
 import { SubmitShiftModal } from "@/features/home/sidebar/components/SubmitShiftModal";
 import { ViewModeButton } from "@/features/home/calendar/components/ViewModeButton";
 import { format, addWeeks, subWeeks, startOfWeek, endOfWeek } from "date-fns";
 import "@/features/home/Home.css";
 import { ShiftSubmissionContext } from "@/features/context/ShiftSubmissionContext";
+import { Shift } from "@/features/home/calendar/types";
 
 export default function Home() {
 	const [date, setDate] = useState(new Date());
 	const [viewMode, setViewMode] = useState('week');
 	const shiftSubmission = useContext(ShiftSubmissionContext);
+
+	// 登録予定シフト
+	const [draftShifts, setDraftShifts] = useState<Shift[]>([]);
 
 	const _start_date = format(startOfWeek(date), 'yyyy年MM月');
 	const _end_date = format(endOfWeek(date), 'yyyy年MM月');
@@ -33,7 +38,7 @@ export default function Home() {
 				);
 			case 'week':
 				return (
-					<WeekAxisCalendar date={date} setDate={setDate} />
+					<WeekAxisCalendar draftShifts={draftShifts} setDraftShifts={setDraftShifts} date={date} setDate={setDate} />
 				);
 			case 'day':
 				return (
@@ -42,7 +47,7 @@ export default function Home() {
 				);
 			default:
 				return (
-					<WeekAxisCalendar date={date} setDate={setDate} />
+					<WeekAxisCalendar draftShifts={draftShifts} setDraftShifts={setDraftShifts} date={date} setDate={setDate} />
 				);
 		}
 	};
@@ -63,6 +68,9 @@ export default function Home() {
 					</div>
 				</div>
 				{CalendarMode()}
+				{draftShifts.length > 0 && (
+					<RegisterDraftShiftsButton draftShifts={draftShifts} />
+				)}
 			</div>
 		</div>
 	);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import Header from "@/app/components/layout/header";
 import Footer from "@/app/components/layout/footer";
 import { UserProvider } from "@/features/context/UserContext";
 import { ShiftSubmissionProvider } from "@/features/context/ShiftSubmissionContext";
+import { TokenProvider } from "@/features/context/AuthContext";
 
 export const metadata: Metadata = {
 	title: "minshif",
@@ -18,13 +19,15 @@ export default function RootLayout({
 	return (
 		<html lang="ja">
 			<body className="h-90v">
-				<UserProvider>
-					<ShiftSubmissionProvider>
-						<Header />
-							{children}
-						<Footer />
-					</ShiftSubmissionProvider>
-				</UserProvider>
+				<TokenProvider>
+					<UserProvider>
+						<ShiftSubmissionProvider>
+							<Header />
+								{children}
+							<Footer />
+						</ShiftSubmissionProvider>
+					</UserProvider>
+				</TokenProvider>
 			</body>
 		</html>
 	);

--- a/src/features/context/AuthContext.tsx
+++ b/src/features/context/AuthContext.tsx
@@ -1,0 +1,32 @@
+"use client"
+import React, { createContext, useContext, useState, ReactNode, useEffect } from 'react';
+import { useCookies } from 'react-cookie';
+
+interface Token {
+	token: string;
+}
+
+export const TokenContext = createContext<Token | undefined>(undefined);
+
+export const TokenProvider = ({ children }: { children: ReactNode }) => {
+	const [token, setToken] = useState<string>("");
+	const [cookies] = useCookies(['token']);
+
+	useEffect(() => {
+		setToken(cookies.token);
+	}, [cookies.token]);
+
+	return (
+		<TokenContext.Provider value={{ token }}>
+			{children}
+		</TokenContext.Provider>
+	);
+};
+
+export const useToken = () => {
+	const context = useContext(TokenContext);
+	if (!context) {
+		throw new Error('useTokenはTokenProviderの中でのみ使用できます');
+	}
+	return context;
+};

--- a/src/features/home/Home.css
+++ b/src/features/home/Home.css
@@ -61,20 +61,27 @@
  * サイドバー
  */
 /** シフト提出 **/
-#overlay{
+.overlay{
 	position:fixed;
 	top:0;
 	left:0;
 	width:100%;
 	height:100%;
-	background-color:rgba(0,0,0,0.5);
 	z-index: 2;
 	display: flex;
 	align-items: center;
 	justify-content: center;
 }
 
-#content {
+.modalSubmitColor {
+	background-color:rgba(0,0,0,0.5);
+}
+
+.modalDraftColor {
+	background-color:rgba(0,0,0,0.1);
+}
+
+.content {
 	width: 50%;
 	padding: 1em;
 	background-color: #fff;

--- a/src/features/home/api/FetchShiftList.ts
+++ b/src/features/home/api/FetchShiftList.ts
@@ -1,0 +1,38 @@
+const FetchShiftList = async ( token: string, start_date: string, end_date: string):
+Promise<{
+	id: number,
+	user_name: string,
+	date: string,
+	start_time: string,
+	end_time: string,
+	notes: string,
+	is_registered: boolean
+}[][]> => {
+	try{
+		const query = new URLSearchParams({
+			'fetch_shift[start_date]': start_date,
+			'fetch_shift[end_date]': end_date
+		}).toString();
+
+		const response = await fetch(process.env.NEXT_PUBLIC_API_URL + `/shift/fetch_shifts?${query}`, {
+			method: 'GET',
+			headers: {
+				'Content-Type': 'application/json',
+				'Authorization': 'Bearer ' + token
+			}
+		});
+
+		if (!response.ok) {
+			throw new Error('再ログインしてください');
+		}
+
+		const data = await response.json();
+
+		return data['staff_shift_list'];
+	} catch(error) {
+		console.error(error);
+		return [];
+	}
+}
+
+export default FetchShiftList;

--- a/src/features/home/api/FetchStaffList.ts
+++ b/src/features/home/api/FetchStaffList.ts
@@ -1,0 +1,24 @@
+const FetchStaffList = async ( token: string ): Promise<{id: number, privilege: string, user_name: string}[]> => {
+	try{
+		const response = await fetch(process.env.NEXT_PUBLIC_API_URL + '/store/staff_list', {
+			method: 'GET',
+			headers: {
+				'Content-Type': 'application/json',
+				'Authorization': 'Bearer ' + token
+			},
+		});
+
+		if (!response.ok) {
+			throw new Error('再ログインしてください');
+		}
+
+		const data = await response.json();
+
+		return data['staff_list'];
+	} catch(error) {
+		console.error(error);
+		return [];
+	}
+}
+
+export default FetchStaffList;

--- a/src/features/home/api/RegisterDraftShifts.ts
+++ b/src/features/home/api/RegisterDraftShifts.ts
@@ -1,0 +1,26 @@
+import { Shift } from '../calendar/types';
+
+const RegisterDraftShifts = async (draftShifts: Shift[]) => {
+	try {
+		const response = await fetch(process.env.NEXT_PUBLIC_API_URL + '/shift/register_draft_shifts', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({
+				'draft_shifts': draftShifts
+			})
+		});
+		if (!response.ok) {
+			throw new Error('再ログインしてください');
+		}
+		const data = await response.json();
+
+		return data;
+	} catch (error) {
+		console.error("Failed to register draft shifts", error);
+		return {'error': error};
+	}
+}
+
+export default RegisterDraftShifts;

--- a/src/features/home/calendar/components/draftShift/DraftShiftModal.tsx
+++ b/src/features/home/calendar/components/draftShift/DraftShiftModal.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { DraftShiftModalContent } from "@/features/home/calendar/components/draftShift/DraftShiftModalContent";
+import { Staff, Shift, setDraftShifts } from "../../types";
+
+const DraftShiftModal = ({
+	isOpen,
+	date,
+	staff,
+	shift,
+	setDraftShifts,
+	onClose
+}: {
+	isOpen: boolean,
+	date: string,
+	staff: Staff,
+	shift: Shift | null,
+	setDraftShifts: setDraftShifts,
+	onClose: () => void
+}) => {
+	if (!isOpen) return null;
+
+	return (
+		<div className="overlay modalDraftColor" onClick={onClose}>
+			<div className="content" onClick={(e) => {e.stopPropagation()}}>
+				<DraftShiftModalContent date={date} staff={staff} shift={shift} setDraftShifts={setDraftShifts} onClose={onClose} />
+			</div>
+		</div>
+	);
+};
+
+export default DraftShiftModal;

--- a/src/features/home/calendar/components/draftShift/DraftShiftModalContent.tsx
+++ b/src/features/home/calendar/components/draftShift/DraftShiftModalContent.tsx
@@ -1,0 +1,113 @@
+import React, { useRef } from "react";
+import { Staff, Shift, setDraftShifts } from "../../types";
+import { formatTimeToISO, format_jp_date, format_time, isStartTimeBeforeEndTime } from "@/features/util/datetime";
+
+export const DraftShiftModalContent = ({
+	date,
+	staff,
+	shift,
+	setDraftShifts,
+	onClose
+}: {
+	date: string,
+	staff: Staff,
+	shift: Shift | null,
+	setDraftShifts: setDraftShifts,
+	onClose: () => void
+}) => {
+	const startTimeRef = useRef<HTMLInputElement>(null);
+	const endTimeRef = useRef<HTMLInputElement>(null);
+	const notesRef = useRef<HTMLInputElement>(null);
+
+	const _start_time = shift ? format_time(shift.start_time) : "00:00";
+	const _end_time = shift ? format_time(shift.end_time) : "00:00";
+	const _notes = shift ? shift.notes : "";
+
+	/**
+	 * 仮登録
+	 */
+	const handleDraftRegister = () => {
+		const start_time = startTimeRef.current ? startTimeRef.current.value : "";
+		const end_time = endTimeRef.current ? endTimeRef.current.value : "";
+		const notes = notesRef.current ? notesRef.current.value : "";
+
+		if (!isStartTimeBeforeEndTime(start_time, end_time)) {
+			alert("開始時間が終了時間と同じか，終了時間よりも過去の時間を選択しています。");
+			return;
+		}
+
+		setDraftShifts((prev) => {
+			const newDraftShifts = prev.filter((draft) => new Date(draft.date).getTime() !== new Date(date).getTime());
+			newDraftShifts.push({
+				id: shift ? shift.id : -1,
+				user_name: staff.user_name,
+				date: date,
+				start_time: formatTimeToISO(start_time),
+				end_time: formatTimeToISO(end_time),
+				notes: notes,
+				is_registered: true
+			});
+			return newDraftShifts;
+		});
+
+		onClose();
+	}
+
+	return (
+		<>
+			<div className="modalContent">
+				シフト登録
+			</div>
+			<hr/>
+			<div>
+				<div className="modalTarget">
+					<div className="font-bold">
+						対象スタッフ
+					</div>
+					<div>
+						{staff.user_name}
+					</div>
+				</div>
+				<div className="modalTarget">
+					<div className="font-bold">
+						勤務日時
+					</div>
+					<div>
+						{format_jp_date(date)}
+					</div>
+				</div>
+				<div className="modalTarget">
+					<div className="font-bold">
+						希望シフト時間
+					</div>
+					<div>
+						{shift && _end_time !== '00:00' ? _start_time + "〜" + _end_time : "未登録"}
+					</div>
+				</div>
+				<div className="modalTarget">
+					<div className="font-bold">
+						シフト時間
+					</div>
+					<div>
+						<input type="time" name="start_time" defaultValue={_start_time} ref={startTimeRef} />
+						〜
+						<input type="time" name="end_time" defaultValue={_end_time} ref={endTimeRef} />
+					</div>
+				</div>
+				<div className="modalTarget">
+					<div className="font-bold">
+						備考
+					</div>
+					<div>
+						<input type="text" name="notes" defaultValue={_notes} ref={notesRef} />
+					</div>
+				</div>
+			</div>
+			<hr/>
+			<div className="flex justify-between">
+				<button onClick={onClose}>閉じる</button>
+				<button type="button" className="bg-amber-500 px-5" onClick={handleDraftRegister}>仮登録</button>
+			</div>
+		</>
+	);
+}

--- a/src/features/home/calendar/components/draftShift/RegisterDraftShiftsButton.tsx
+++ b/src/features/home/calendar/components/draftShift/RegisterDraftShiftsButton.tsx
@@ -1,0 +1,21 @@
+import RegisterDraftShifts from "@/features/home/api/RegisterDraftShifts";
+import { Shift } from "../../types";
+
+const RegisterDraftShiftsButton = ({draftShifts}: {draftShifts: Shift[]}) => {
+	const handleRegisterDraftShifts = async () => {
+		const data = await RegisterDraftShifts(draftShifts);
+		if (data.error) {
+			alert(data.error);
+		} else {
+			alert(data.message);
+		}
+	};
+
+	return (
+		<div className="flex justify-center">
+			<button className="bg-sky-500" onClick={handleRegisterDraftShifts}>シフト確定</button>
+		</div>
+	);
+}
+
+export default RegisterDraftShiftsButton;

--- a/src/features/home/calendar/components/weekAxis/WeekAxis.css
+++ b/src/features/home/calendar/components/weekAxis/WeekAxis.css
@@ -13,7 +13,7 @@
  .weekCalendarContainer {
 	width: 100%;
 	overflow-y: hidden;
-	min-width: 800px;
+	min-width: 1025px;
 	max-height: 1535px;
 }
 
@@ -155,12 +155,17 @@
 	position: relative;
 }
 
-.empty {
-	height: 60px;
+.cell {
+	height: 30px;
 	width: 100%;
 	display: block;
 }
-.empty:hover {
+.cell:hover {
 	cursor: pointer;
 	background: rgba(0, 162, 106, 0.04);
+}
+
+.shift:hover {
+	cursor: pointer;
+	background-color: blue;
 }

--- a/src/features/home/calendar/components/weekAxis/WeekAxisCalendar.tsx
+++ b/src/features/home/calendar/components/weekAxis/WeekAxisCalendar.tsx
@@ -5,7 +5,7 @@ import { WeekShift } from "./WeekShift";
 import { WeekAxisCalendarProps } from "@/features/home/calendar/types";
 import "./WeekAxis.css";
 
-export const WeekAxisCalendar = ({ date, setDate }: WeekAxisCalendarProps) => {
+export const WeekAxisCalendar = ({ date, setDate, draftShifts, setDraftShifts }: WeekAxisCalendarProps) => {
 	const _day = getDay(date);
 	const _start_date = subDays(date, _day);
 
@@ -24,7 +24,7 @@ export const WeekAxisCalendar = ({ date, setDate }: WeekAxisCalendarProps) => {
 
 	return (
 		<div role="grid" aria-readonly="true" className="weekCalendarContainer">
-			<WeekShift dayList={dayList} />
+			<WeekShift dayList={dayList} draftShifts={draftShifts} setDraftShifts={setDraftShifts} />
 		</div>
 	);
 }

--- a/src/features/home/calendar/components/weekAxis/WeekAxisCalendar.tsx
+++ b/src/features/home/calendar/components/weekAxis/WeekAxisCalendar.tsx
@@ -22,17 +22,9 @@ export const WeekAxisCalendar = ({ date, setDate }: WeekAxisCalendarProps) => {
 			return { day: day, date: dateFormat };
 		});
 
-	const factorList = [
-		{id: 1, name: "労働時間合計"},
-		{id: 2, name: "人件費"},
-		{id: 3, name: "Aさん"},
-		{id: 4, name: "Bさん"},
-		{id: 5, name: "管理者S"}
-	];
-
 	return (
 		<div role="grid" aria-readonly="true" className="weekCalendarContainer">
-			<WeekShift dayList={dayList} factorList={factorList} />
+			<WeekShift dayList={dayList} />
 		</div>
 	);
 }

--- a/src/features/home/calendar/components/weekAxis/WeekShift.tsx
+++ b/src/features/home/calendar/components/weekAxis/WeekShift.tsx
@@ -1,16 +1,36 @@
 import { DAY_LIST } from "../constant/index";
-import { DayList, FactorList } from "../../types/index";
+import { DayList, StaffList } from "../../types/index";
+import { useEffect, useState } from "react";
+import FetchStaffList from "@/features/home/api/FetchStaffList";
+import { useToken } from "@/features/context/AuthContext";
 
-export const WeekShift = ({ dayList, factorList }: {dayList: DayList, factorList: FactorList }) => {
+export const WeekShift = ({ dayList }: { dayList: DayList }) => {
+	const [staffList, setStaffList] = useState<StaffList>([]);
+	const token = useToken();
+
+	useEffect(() => {
+		const fetchStaff = async () => {
+			if (token.token !== '') {
+				try {
+					const response = await FetchStaffList(token.token);
+					setStaffList(response);
+				} catch (error) {
+					console.error("Failed to fetch staff list", error);
+				}
+			}
+		};
+		fetchStaff();
+	}, [token]);
+
 	const EmptyCell = (date: { date: string }) => {
 		return (
 		<>
-			{factorList.map((factor) => {
+			{Object.entries(staffList).map(([key, staff]) => {
 				return (
 					<div
-						key={factor.name}
+						key={key}
 						onClick={() => {
-							console.log(date, `${factor.name}時`);
+							console.log(date, `${staff.user_name}時`);
 						}}
 						className="empty"
 					/>
@@ -58,13 +78,11 @@ export const WeekShift = ({ dayList, factorList }: {dayList: DayList, factorList
 			<div className="shiftContainer">
 				<div className="timeslotBox">
 					<ul className="shiftList">
-						{factorList.map((factor) => {
-							return (
-								<li key={factor.id} className="timeslotItem">
-									{factor.name}
-								</li>
-							);
-						})}
+					{Object.entries(staffList).map(([key, staff]) => (
+						<li key={key} className="timeslotItem">
+							{staff.user_name}
+						</li>
+					))}
 					</ul>
 				</div>
 				<div className="element-space"/>
@@ -72,8 +90,8 @@ export const WeekShift = ({ dayList, factorList }: {dayList: DayList, factorList
 				<div className="calendarContainer">
 					<div className="calendarWrapper">
 						<div>
-							{factorList.map((factor) => (
-								<div key={factor.id}>
+							{Object.entries(staffList).map(([key, staff]) => (
+								<div key={key}>
 									<div className="horizontalHeight" />
 								</div>
 							))}

--- a/src/features/home/calendar/components/weekAxis/WeekShift.tsx
+++ b/src/features/home/calendar/components/weekAxis/WeekShift.tsx
@@ -1,13 +1,19 @@
 import { DAY_LIST } from "../constant/index";
-import { DayList, StaffList } from "../../types/index";
+import { DayList, StaffList, ShiftList } from "../../types/index";
 import { useEffect, useState } from "react";
 import FetchStaffList from "@/features/home/api/FetchStaffList";
+import FetchShiftList from "@/features/home/api/FetchShiftList";
 import { useToken } from "@/features/context/AuthContext";
+import { addDays } from "date-fns";
 
 export const WeekShift = ({ dayList }: { dayList: DayList }) => {
 	const [staffList, setStaffList] = useState<StaffList>([]);
+	const [shiftList, setShiftList] = useState<ShiftList>([]);
 	const token = useToken();
 
+	/**
+	 * スタッフ・シフトリストの取得
+	 */
 	useEffect(() => {
 		const fetchStaff = async () => {
 			if (token.token !== '') {
@@ -19,25 +25,75 @@ export const WeekShift = ({ dayList }: { dayList: DayList }) => {
 				}
 			}
 		};
+
+		const fetchShift = async () => {
+			if (token.token !== '') {
+				try {
+					const start_date = addDays(new Date(dayList[0].date), -7).toString();
+					const end_date = addDays(new Date(dayList[0].date), 7).toString();
+					const response = await FetchShiftList(token.token, start_date, end_date);
+					setShiftList(response);
+				} catch (error) {
+					console.error("Failed to fetch shift list", error);
+				}
+			}
+		};
+
 		fetchStaff();
+		fetchShift();
 	}, [token]);
 
-	const EmptyCell = (date: { date: string }) => {
-		return (
-		<>
-			{Object.entries(staffList).map(([key, staff]) => {
-				return (
-					<div
-						key={key}
-						onClick={() => {
-							console.log(date, `${staff.user_name}時`);
-						}}
-						className="empty"
-					/>
+	/**
+	 * シフトのセル
+	 * @param date
+	 * @returns jsx
+	 */
+	const Cell = ({ date }: { date: string }) => {
+		if (shiftList.length === 0) {
+			return (
+				<>
+					{Object.entries(staffList).map(([key, staff]) => {
+						return (
+							<div
+								key={key}
+								onClick={() => {
+									console.log(date, `${staff.user_name}時`);
+								}}
+								className="empty"
+							/>
+						);
+					})}
+				</>
 				);
-			})}
-		</>
-		);
+		} else {
+			return (
+			<>
+				{/* スタッフ全員分のセルを作成 */}
+				{staffList.map((staff, staffIndex) => (
+					<div key={staffIndex}>
+						{/* シフトがある場合のみ開始と終了時間を表示 */}
+						{shiftList[staffIndex]?.map((shift, shiftIndex) => {
+							if (!shift || !staff) {
+								return null;
+							} else if (shift.date === date && shift.user_name === staff.user_name) {
+								return (
+									<div
+										key={shift.id}
+										onClick={() => {
+											console.log(date, `${shift.user_name}時`);
+										}}
+										className="shift"
+									>
+										{shift.start_time} : {shift.end_time}
+									</div>
+								);
+							}
+						})}
+					</div>
+				))}
+			</>
+			);
+		}
 	};
 
 	return (
@@ -103,7 +159,7 @@ export const WeekShift = ({ dayList }: { dayList: DayList }) => {
 										key={dayItem.date}
 										className="calendarColumn"
 									>
-										<EmptyCell date={dayItem.date} />
+										<Cell date={dayItem.date} />
 									</div>
 								);
 							})}

--- a/src/features/home/calendar/types/index.ts
+++ b/src/features/home/calendar/types/index.ts
@@ -6,6 +6,18 @@ export interface Staff {
 
 export type StaffList = Staff[];
 
+export interface Shift {
+	id: number,
+	user_name: string,
+	date: string,
+	start_time: string,
+	end_time: string,
+	notes: string,
+	is_registered: boolean
+};
+
+export type ShiftList = Shift[][];
+
 export interface Day {
 	day: number;
 	date: string;

--- a/src/features/home/calendar/types/index.ts
+++ b/src/features/home/calendar/types/index.ts
@@ -1,4 +1,4 @@
-export interface Staff {
+export type Staff = {
 	id: number;
 	privilege: string;
 	user_name: string;
@@ -6,7 +6,26 @@ export interface Staff {
 
 export type StaffList = Staff[];
 
-export interface Shift {
+export type Shift = {
+	id: number;
+	user_name: string;
+	date: string;
+	start_time: string;
+	end_time: string;
+	notes: string;
+	is_registered: boolean;
+};
+
+export type ShiftList = Shift[][];
+
+export type WeekAxisCalendarProps = {
+	date: Date;
+	setDate: React.Dispatch<React.SetStateAction<Date>>;
+	draftShifts: Shift[],
+	setDraftShifts: setDraftShifts;
+}
+
+export type setDraftShifts = React.Dispatch<React.SetStateAction<Array<{
 	id: number,
 	user_name: string,
 	date: string,
@@ -14,23 +33,16 @@ export interface Shift {
 	end_time: string,
 	notes: string,
 	is_registered: boolean
-};
+}>>>;
 
-export type ShiftList = Shift[][];
-
-export interface Day {
+export type Day = {
 	day: number;
 	date: string;
 };
 
 export type DayList = Day[];
 
-export interface ViewModeButtonProps {
+export type ViewModeButtonProps = {
 	viewMode: string;
 	setViewMode: React.Dispatch<React.SetStateAction<string>>;
 };
-
-export interface WeekAxisCalendarProps {
-	date: Date;
-	setDate: React.Dispatch<React.SetStateAction<Date>>;
-}

--- a/src/features/home/calendar/types/index.ts
+++ b/src/features/home/calendar/types/index.ts
@@ -1,9 +1,10 @@
-export interface Factor {
+export interface Staff {
 	id: number;
-	name: string;
+	privilege: string;
+	user_name: string;
 };
 
-export type FactorList = Factor[];
+export type StaffList = Staff[];
 
 export interface Day {
 	day: number;

--- a/src/features/home/shift/components/RegShiftModalContent.tsx
+++ b/src/features/home/shift/components/RegShiftModalContent.tsx
@@ -1,0 +1,50 @@
+export const RegShiftModalContent = ({ setIsOpen }: { setIsOpen: React.Dispatch<React.SetStateAction<boolean>>}) => {
+
+	async function registerShift(e: any) {
+		e.preventDefault();
+	};
+
+	return (
+		<>
+			<div className="modalContent">
+				シフト登録
+			</div>
+			<hr/>
+			<form onSubmit={registerShift}>
+				<div>
+					<div className="modalTarget">
+						<div className="font-bold">
+							対象スタッフ
+						</div>
+						<div>
+							全てのスタッフ
+						</div>
+					</div>
+					<div className="modalTarget">
+						<div className="font-bold">
+							対象期間
+						</div>
+						<div>
+							<input type="time" name="start_time" />
+							〜
+							<input type="time" name="end_time" />
+						</div>
+					</div>
+					<div className="modalTarget">
+						<div className="font-bold">
+							備考
+						</div>
+						<div>
+							<input type="text" name="notes" />
+						</div>
+					</div>
+				</div>
+				<hr/>
+				<div>
+					<button onClick={() => setIsOpen(false)}>閉じる</button>
+					<button type="submit" className="bg-slate-900/5 px-5">スタッフに送信する</button>
+				</div>
+			</form>
+		</>
+	);
+}

--- a/src/features/home/sidebar/components/SubmitShiftModal.tsx
+++ b/src/features/home/sidebar/components/SubmitShiftModal.tsx
@@ -11,13 +11,12 @@ export const SubmitShiftModal = () => {
 
 	return (
 		<div>
-			{/** TODO: 既に提出済みなら無効に */}
 			<button className="submitShift" onClick={() => setSubmitShiftModal(true)}>
 				シフト提出依頼
 			</button>
 			{submitShiftModal && (
-				<div id="overlay" className="submitShiftOverlay" onClick={handleOverlayClick}>
-					<div id="content" onClick={(e) => e.stopPropagation()}>
+				<div className="overlay modalSubmitColor" onClick={handleOverlayClick}>
+					<div className="content" onClick={(e) => e.stopPropagation()}>
 						<SubmitShiftModalContent setSubmitShiftModal={setSubmitShiftModal} />
 					</div>
 				</div>

--- a/src/features/util/datetime.ts
+++ b/src/features/util/datetime.ts
@@ -1,0 +1,43 @@
+/**
+ * 指定された時刻に9時間を加算し、ISO形式の時刻文字列を返す関数
+ *
+ * @param time - 変換対象の時刻文字列（HH:MM形式）
+ * @returns 9時間加算されたISO形式の時刻文字列
+ */
+export const formatTimeToISO = (time: string): string => {
+	const date = new Date(`2000-01-01T${time}:00.000+09:00`);
+	date.setHours(date.getHours() + 9);
+
+	return date.toISOString().split('.')[0] + ".000+09:00";
+}
+
+/**
+ * YYYY-MM-DD to YYYY年MM月DD日
+ * @param date - YYYY-MM-DD形式
+ * @returns YYYY年MM月DD日
+ */
+export const format_jp_date = (date: string) => {
+	return date.replace(/^(\d{4})-(\d{2})-(\d{2})$/, '$1年$2月$3日');
+}
+
+/**
+ * ISO8601形式の時刻文字列をHH:MM形式に変換する関数
+ * @param time - ISO8601形式(YYYY-MM-DDTHH:MM:SSZ)
+ * @returns HH:MM形式
+ */
+export const format_time = (time: string) => {
+	return time.split('T')[1].slice(0, 5);
+}
+
+
+/**
+ * 開始時間が終了時間より未来の時間を選択しているか判定する関数
+ * @param startTime - 比較対象の開始時間（HH:MM形式）
+ * @param endTime - 比較対象の終了時間（HH:MM形式）
+ * @returns boolean - 正常な時間の選択であれば true
+ */
+export const isStartTimeBeforeEndTime = (startTime: string, endTime: string): boolean => {
+	const startDate = new Date(`2000-01-01T${startTime}:00`);
+	const endDate = new Date(`2000-01-01T${endTime}:00`);
+	return startDate.getTime() < endDate.getTime();
+};


### PR DESCRIPTION
## 概要
スタッフのシフト一覧を取得し，テーブルのセルに表示する機能を追加しました．

## 変更点
- トークンのコンテキスト化
- 同じ店舗に属するスタッフのシフト一覧取得
- スタッフ一覧を取得してテーブルに反映
- 前後1週間のシフト一覧取得
- シフトの種類ごとに表示の使い分け
- 確定シフトの登録


## 影響範囲
- Homeのシフトを管理するテーブル全体
- トークンのコンテキストを追加したことによる全体への影響


## 動作要件
- [ ] ログインユーザが`staff`の場合，登録済みシフトのみが取得される
- [ ] ログインユーザが`manager`の場合，希望シフト及び登録済みシフトが取得される
- [ ] シフトが登録されていない日付は何も表示されない


## テスト
- 希望シフトと登録済みシフトを登録後，`manager`でログイン
- 希望シフトと登録済みシフトを登録後，`staff`ユーザでログイン


## 関連Issue
- 関連Issue: #9 


## 補足
- 一度取得したシフト情報はキャッシュするようにする．
    - 関連Issue: #11