### PR TITLE
[Fix]登録予定シフト提出修正

### DIFF
--- a/src/app/shift/preferredShift/page.tsx
+++ b/src/app/shift/preferredShift/page.tsx
@@ -4,18 +4,19 @@ import { PreferredShiftForm } from "@/features/home/calendar/components/preferre
 import { PreferredShiftCalendar } from "@/features/home/calendar/components/preferredShift/PreferredShiftCalendar";
 import { startOfDay } from "date-fns";
 import { ShiftSubmissionContext } from "@/features/context/ShiftSubmissionContext";
+import { Shift } from "@/features/home/calendar/types";
 
 export default function SubmitPreferredShift() {
 	const shiftSubmission = useContext(ShiftSubmissionContext);
 
-	const startDate = shiftSubmission && shiftSubmission.shiftSubmissionRequest.length > 0 ? startOfDay(new Date(shiftSubmission.shiftSubmissionRequest[0].start_date)) : startOfDay(new Date());
+	const startDate = shiftSubmission && shiftSubmission?.shiftSubmissionRequest.length > 0 ? startOfDay(new Date(shiftSubmission.shiftSubmissionRequest[0].start_date)) : startOfDay(new Date());
 	const endDate = shiftSubmission && shiftSubmission?.shiftSubmissionRequest.length > 0 ? startOfDay(new Date(shiftSubmission.shiftSubmissionRequest[0].end_date)) : startOfDay(new Date());
 	// 参照している日付
 	const [date, setDate] = useState(startDate);
 	const dateRef = useRef<Date>(startDate);
 
 	// 仮希望シフト
-	const [shifts, setShifts] = useState<Array<{ date: Date, startTime: string, endTime: string, notes: string }>>([]);
+	const [shifts, setShifts] = useState<Array<Shift>>([]);
 
 	return (
 		<div className="grid grid-cols-12">

--- a/src/features/context/AuthContext.tsx
+++ b/src/features/context/AuthContext.tsx
@@ -1,10 +1,7 @@
 "use client"
 import React, { createContext, useContext, useState, ReactNode, useEffect } from 'react';
 import { useCookies } from 'react-cookie';
-
-interface Token {
-	token: string;
-}
+import { Token } from '@/features/home/calendar/types';
 
 export const TokenContext = createContext<Token | undefined>(undefined);
 

--- a/src/features/home/api/FetchShiftList.ts
+++ b/src/features/home/api/FetchShiftList.ts
@@ -1,13 +1,6 @@
-const FetchShiftList = async ( token: string, start_date: string, end_date: string):
-Promise<{
-	id: number,
-	user_name: string,
-	date: string,
-	start_time: string,
-	end_time: string,
-	notes: string,
-	is_registered: boolean
-}[][]> => {
+import { Shift } from '../calendar/types';
+
+const FetchShiftList = async ( token: string, start_date: string, end_date: string): Promise<Shift[][]> => {
 	try{
 		const query = new URLSearchParams({
 			'fetch_shift[start_date]': start_date,

--- a/src/features/home/api/RegisterDraftShifts.ts
+++ b/src/features/home/api/RegisterDraftShifts.ts
@@ -1,10 +1,11 @@
-import { Shift } from '../calendar/types';
+import { Shift, Token } from '../calendar/types';
 
-const RegisterDraftShifts = async (draftShifts: Shift[]) => {
+const RegisterDraftShifts = async (token: Token | undefined, draftShifts: Shift[]) => {
 	try {
 		const response = await fetch(process.env.NEXT_PUBLIC_API_URL + '/shift/register_draft_shifts', {
 			method: 'POST',
 			headers: {
+				'Authorization': 'Bearer ' + token?.token,
 				'Content-Type': 'application/json',
 			},
 			body: JSON.stringify({

--- a/src/features/home/api/RegisterPreferredShifts.ts
+++ b/src/features/home/api/RegisterPreferredShifts.ts
@@ -1,9 +1,4 @@
-interface Shift {
-	date: Date;
-	startTime: string;
-	endTime: string;
-	notes: string;
-}
+import { Shift } from '../calendar/types';
 
 const RegisterPreferredShifts = async ( preferredShifts: Shift[], token: string ) => {
 	try {

--- a/src/features/home/calendar/components/draftShift/DraftShiftModalContent.tsx
+++ b/src/features/home/calendar/components/draftShift/DraftShiftModalContent.tsx
@@ -32,20 +32,21 @@ export const DraftShiftModalContent = ({
 		const notes = notesRef.current ? notesRef.current.value : "";
 
 		if (!isStartTimeBeforeEndTime(start_time, end_time)) {
-			alert("開始時間が終了時間と同じか，終了時間よりも過去の時間を選択しています。");
+			alert("開始時間が終了時間と同じか，過去の時間を選択しています。");
 			return;
 		}
 
 		setDraftShifts((prev) => {
 			const newDraftShifts = prev.filter((draft) => new Date(draft.date).getTime() !== new Date(date).getTime());
 			newDraftShifts.push({
-				id: shift ? shift.id : -1,
+				id: shift ? shift.id : null,
 				user_name: staff.user_name,
 				date: date,
 				start_time: formatTimeToISO(start_time),
 				end_time: formatTimeToISO(end_time),
 				notes: notes,
-				is_registered: true
+				is_registered: true,
+				shift_submission_request_id: shift && shift != undefined ? shift.shift_submission_request_id : null
 			});
 			return newDraftShifts;
 		});

--- a/src/features/home/calendar/components/draftShift/RegisterDraftShiftsButton.tsx
+++ b/src/features/home/calendar/components/draftShift/RegisterDraftShiftsButton.tsx
@@ -1,9 +1,13 @@
+import React, { useContext } from "react";
+import { TokenContext } from "@/features/context/AuthContext";
 import RegisterDraftShifts from "@/features/home/api/RegisterDraftShifts";
 import { Shift } from "../../types";
 
 const RegisterDraftShiftsButton = ({draftShifts}: {draftShifts: Shift[]}) => {
+	const token = useContext(TokenContext);
+
 	const handleRegisterDraftShifts = async () => {
-		const data = await RegisterDraftShifts(draftShifts);
+		const data = await RegisterDraftShifts(token, draftShifts);
 		if (data.error) {
 			alert(data.error);
 		} else {

--- a/src/features/home/calendar/components/preferredShift/PreferredShiftCalendar.tsx
+++ b/src/features/home/calendar/components/preferredShift/PreferredShiftCalendar.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { DAY_LIST } from "@/features/home/calendar/components/constant/index";
 import { fetchSixWeekDay } from '../constant/fetchSixWeekDay';
-
-const JP_LOCALE = 9 * 3600000;
+import { Shift } from '../../types';
+import { extractYMD } from '@/features/util/datetime';
 
 // 標準時刻を取得
 const stripTime = (date: Date) => new Date(date.getFullYear(), date.getMonth(), date.getDate());
@@ -22,7 +22,7 @@ export const PreferredShiftCalendar = (
 	selectedDate: Date,
 	startDate: Date,
 	endDate: Date,
-	shifts: Array<{ date: Date, startTime: string, endTime: string, notes: string }>,
+	shifts: Array<Shift>,
 	setDate: React.Dispatch<React.SetStateAction<Date>>
 }) => {
 	const weeks = fetchSixWeekDay(stripTime(startDate));
@@ -53,6 +53,7 @@ export const PreferredShiftCalendar = (
 								className="text-2xl h-16 w-full flex items-center justify-center flex-auto"
 							>
 								<div className="w-10 h-10">
+									{/* カレンダーの日付表示 */}
 									{(startDate <= date && date <= endDate) ?
 										(
 											<button
@@ -72,10 +73,9 @@ export const PreferredShiftCalendar = (
 											</div>
 										)
 									}
+									{/* 予定がある場合，その日付に ● マークをつける */}
 									{shifts.map((shift, shiftIndex) => {
-										const shiftDate = new Date(shift.date.getTime() - JP_LOCALE);
-										const shiftDay = shiftDate.toString();
-										if (shiftDay === date.toString()) {
+										if (extractYMD(shift.date) === extractYMD(date.toString())) {
 											return (
 												<div key={`shift-${weekIndex}-${dateIndex}-${shiftIndex}`} className="w-full flex justify-center">
 													<div className="w-2 h-2 rounded-full bg-slate-300 mt-1" />

--- a/src/features/home/calendar/types/index.ts
+++ b/src/features/home/calendar/types/index.ts
@@ -7,16 +7,23 @@ export type Staff = {
 export type StaffList = Staff[];
 
 export type Shift = {
-	id: number;
+	id: number | null;
 	user_name: string;
 	date: string;
 	start_time: string;
 	end_time: string;
 	notes: string;
 	is_registered: boolean;
+	shift_submission_request_id: number | null;
 };
 
 export type ShiftList = Shift[][];
+
+export type ShiftHistory = {
+	start_time: string;
+	end_time: string;
+	notes: string;
+};
 
 export type WeekAxisCalendarProps = {
 	date: Date;
@@ -25,15 +32,7 @@ export type WeekAxisCalendarProps = {
 	setDraftShifts: setDraftShifts;
 }
 
-export type setDraftShifts = React.Dispatch<React.SetStateAction<Array<{
-	id: number,
-	user_name: string,
-	date: string,
-	start_time: string,
-	end_time: string,
-	notes: string,
-	is_registered: boolean
-}>>>;
+export type setDraftShifts = React.Dispatch<React.SetStateAction<Array<Shift>>>;
 
 export type Day = {
 	day: number;
@@ -46,3 +45,7 @@ export type ViewModeButtonProps = {
 	viewMode: string;
 	setViewMode: React.Dispatch<React.SetStateAction<string>>;
 };
+
+export type Token = {
+	token: string;
+}

--- a/src/features/util/datetime.ts
+++ b/src/features/util/datetime.ts
@@ -41,3 +41,36 @@ export const isStartTimeBeforeEndTime = (startTime: string, endTime: string): bo
 	const endDate = new Date(`2000-01-01T${endTime}:00`);
 	return startDate.getTime() < endDate.getTime();
 };
+
+/**
+ * 日付のstring型から時間を抽出
+ * @param date - 日付のstring型
+ * @returns 時間のnumber型
+ */
+export const extractTime = (date: string): number => {
+	const date_Obj = new Date(date);
+	return date_Obj.getTime();
+}
+
+/**
+ * 日付のstring型から日付を抽出
+ * @param date - 日付のstring型
+ * @returns 日付のnumber型
+ */
+export const extractDate = (date: string): number => {
+	const date_Obj = new Date(date);
+	return date_Obj.getDate();
+}
+
+/**
+ * 日付のstring型から年月日を抽出
+ * @param date - 日付のstring型
+ * @returns 日付のnumber型
+ */
+export const extractYMD = (date: string): number => {
+	const date_Obj = new Date(date);
+	const year = date_Obj.getFullYear();
+	const month = ('0' + (date_Obj.getMonth() + 1)).slice(-2);
+	const day = ('0' + date_Obj.getDate()).slice(-2);
+	return parseInt(`${year}${month}${day}`, 10);
+}


### PR DESCRIPTION
## 概要
登録予定シフトの提出方式と日付のロジックを修正しました．


## 変更点
- 登録予定シフト登録時にtoken と shift_submission_request_idを追加
- 型定義をファイルへまとめる
- 日付のロジックを追加


## 影響範囲
- 希望シフト登録のカレンダーForm
- 登録予定シフト提出部分のバックエンド処理


## 動作要件
- [ ] いつも通りyarn run devで起動．


## テスト
- [ ] 希望シフト提出の時間追加部分がカレンダーに●として表示される
- [ ] 希望シフト提出後ホームのカレンダーに希望シフトとして表示される


## 関連Issue
- なし


## 補足
- なし