### PR TITLE
[Add]LINE Bot友だち機能追加

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,6 +5,14 @@ const nextConfig = {
 			{
 				protocol: 'https',
 				hostname: 'lh3.googleusercontent.com'
+			},
+			{
+				protocol: 'https',
+				hostname: 'scdn.line-apps.com',
+			},
+			{
+				protocol: 'https',
+				hostname: 'qr-official.line.me',
 			}
 		],
 	},

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -12,6 +12,7 @@ import { MembershipContext } from "@/features/context/MembershipContext";
 import Link from "next/link";
 import { Button, buttonVariants } from "@/features/components/ui/button";
 import { ChevronLeftIcon, ChevronRightIcon } from "@radix-ui/react-icons";
+import { LINEBotButton } from "@/features/home/sidebar/components/line/LINEBotButton";
 
 export default function Home() {
 	const membership = useContext(MembershipContext);
@@ -70,6 +71,8 @@ export default function Home() {
 					<Link href="/store/create" className={buttonVariants({ variant: "outline" })}>
 						店舗作成
 					</Link>
+
+					<LINEBotButton />
 
 					<SelectScrollable />
 					<ViewModeButton viewMode={viewMode} setViewMode={setViewMode} />

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -74,7 +74,6 @@ export default function SignInPage() {
 												e.preventDefault();
 												try {
 													await signIn(provider.id, { callbackUrl: "/redirect" });
-													router.push("/redirect");
 												} catch (error) {
 													if (error instanceof AuthError) {
 														console.error(error);

--- a/src/features/components/CopyButton.tsx
+++ b/src/features/components/CopyButton.tsx
@@ -1,0 +1,52 @@
+
+import { useState } from 'react';
+
+const CopyButton = ({ textToCopy }: { textToCopy: string}) => {
+	const [showMessage, setShowMessage] = useState(false);
+
+	const handleCopy = () => {
+		navigator.clipboard.writeText(textToCopy).then(() => {
+			setShowMessage(true);
+
+			// 2秒後にメッセージを非表示にする
+			setTimeout(() => {
+				setShowMessage(false);
+			}, 2000);
+		}).catch((err) => {
+			console.error('コピーに失敗しました:', err);
+		});
+	};
+
+	return (
+		<div className="relative inline-block">
+			<button
+				onClick={handleCopy}
+				className="text-white px-4 py-2 rounded"
+			>
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					className="h-6 w-6 text-gray-500 hover:text-gray-700"
+					fill="none"
+					viewBox="0 0 24 24"
+					stroke="currentColor"
+				>
+					<path
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						strokeWidth="2"
+						d="M8 7h10M8 11h6m-6 4h10M5 7h14a2 2 0 012 2v10a2 2 0 01-2 2H5a2 2 0 01-2-2V9a2 2 0 012-2z"
+					/>
+				</svg>
+			</button>
+			{showMessage && (
+				<div
+					className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-2 py-1 bg-gray-700 text-white text-sm rounded opacity-100 transition-opacity duration-300 min-w-4"
+				>
+					コピーしました！
+				</div>
+			)}
+		</div>
+	);
+};
+
+export default CopyButton;

--- a/src/features/home/api/FetchAuthCode.ts
+++ b/src/features/home/api/FetchAuthCode.ts
@@ -1,0 +1,30 @@
+interface FetchAuthCodeProps {
+    id: number;
+    user_id: string;
+    auth_code: number;
+    created_at: string;
+    updated_at: string;
+}
+
+const FetchAuthCode = async ( user_id: string ): Promise<FetchAuthCodeProps | null> => {
+	try{
+		const response = await fetch(process.env.NEXT_PUBLIC_API_URL + `/auth_code?user_id=${user_id}`, {
+			method: 'GET',
+			headers: {
+				'Content-Type': 'application/json',
+			}
+		});
+
+		if (!response.ok) {
+			throw new Error('再ログインしてください');
+		}
+		const data = await response.json();
+
+		return data["message"];
+	} catch(error) {
+		console.error(error);
+		return null;
+	}
+}
+
+export default FetchAuthCode;

--- a/src/features/home/api/RegisterAuthCode.ts
+++ b/src/features/home/api/RegisterAuthCode.ts
@@ -1,0 +1,27 @@
+const RegisterAuthCode = async (authCode: number, user_id: string) => {
+	try {
+		const response = await fetch(process.env.NEXT_PUBLIC_API_URL + '/auth_code', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({
+				'user_id': user_id,
+				'auth_code': authCode
+			})
+		});
+
+		if (!response.ok) {
+			const errorData = await response.json();
+			throw new Error(errorData.message || '再ログインしてください');
+		}
+		const data = await response.json();
+
+		return { data: data["message"], error: null };
+	} catch (error) {
+		console.error("Failed to register draft shifts", error);
+		return {'error': error};
+	}
+}
+
+export default RegisterAuthCode;

--- a/src/features/home/sidebar/components/line/AuthCode.ts
+++ b/src/features/home/sidebar/components/line/AuthCode.ts
@@ -1,0 +1,3 @@
+export function AuthCode(): number {
+	return Math.floor(1000 + Math.random() * 9000);
+}

--- a/src/features/home/sidebar/components/line/LINEBotButton.tsx
+++ b/src/features/home/sidebar/components/line/LINEBotButton.tsx
@@ -1,0 +1,117 @@
+import Image from 'next/image';
+import {
+	Dialog,
+	DialogTrigger,
+	DialogContent,
+	DialogHeader,
+	DialogTitle,
+	DialogDescription,
+} from "@/features/components/ui/dialog";
+import { Label } from '@/features/components/ui/label';
+import CopyButton  from '@/features/components/CopyButton';
+import { AuthCode } from '@/features/home/sidebar/components/line/AuthCode';
+import { useContext, useState } from 'react';
+import RegisterAuthCode  from '@/features/home/api/RegisterAuthCode';
+import { UserContext } from '@/features/context/UserContext';
+import FetchAuthCode from '@/features/home/api/FetchAuthCode';
+
+export const LINEBotButton = () => {
+	const user = useContext(UserContext);
+	const [authCode, setAuthCode]= useState<number>(Number(localStorage.getItem('authCode')));
+
+	const handleSetAuthCode = async () => {
+		const authCode = localStorage.getItem('authCode');
+		const authCodeExpiration = localStorage.getItem('authCodeExpiration');
+		const response = await FetchAuthCode(user?.user?.id || '');
+
+		// 認証コードが保存されている場合
+		if (response !== null) {
+			setAuthCode(response["auth_code"]);
+			localStorage.setItem('authCode', String(response["auth_code"]));
+			localStorage.setItem('authCodeExpiration', String(response["updated_at"] + 30 * 60 * 1000));
+			return;
+
+		// 認証コードが無効もしくは期限切れの場合
+		} else if (!authCode || !authCodeExpiration || Date.now() >= Date.parse(authCodeExpiration)) {
+			const code = AuthCode();
+			setAuthCode(code);
+			localStorage.setItem('authCode', String(code));
+			// 認証コードの有効期限30分
+			const newExpiration = new Date(Date.now() + 30 * 60 * 1000);
+			localStorage.setItem('authCodeExpiration', String(newExpiration));
+
+			// 認証コードを保存
+			const user_id = user?.user?.id || '';
+			const data = await RegisterAuthCode(code, user_id);
+
+			// 保存失敗時
+			if (data.error) {
+				localStorage.removeItem('authCode');
+				localStorage.removeItem('authCodeExpiration');
+				alert(data.error);
+			}
+			return;
+		}
+
+		// 認証コードの再利用
+		setAuthCode(Number(authCode));
+	};
+
+	return (
+		<div>
+			<Dialog>
+				<DialogTrigger asChild>
+					<button onClick={handleSetAuthCode}>
+						<Image
+							src="https://scdn.line-apps.com/n/line_add_friends/btn/ja.png"
+							alt="友だち追加"
+							className="inline-flex items-center justify-center rounded-md text-sm font-mediumring-offset-background transition-colors
+							focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2
+							disabled:pointer-events-none disabled:opacity-50 hover:bg-accent hover:text-accent-foreground"
+							height={40}
+							width={120}
+						/>
+					</button>
+				</DialogTrigger>
+
+				<DialogContent
+					className="sm:max-w-[500px] bg-white p-6 rounded-md shadow-lg"
+					onOpenAutoFocus={(e) => e.preventDefault()}
+				>
+					<DialogHeader className='flex justify-center'>
+						<DialogTitle>シフト通知LINE Bot</DialogTitle>
+						<DialogDescription>
+							次の日にシフトが入っている場合に<br className='sm:hidden'></br>通知を送信します
+						</DialogDescription>
+					</DialogHeader>
+					<div className='flex flex-col sm:flex-row justify-start items-center sm:justify-center sm:items-center text-center'>
+						<div className='order-2 sm:order-1'>
+							<Image
+								src="https://qr-official.line.me/gs/M_841bfcng_GW.png?oat_content=qr"
+								alt="LINE Bot QR Code"
+								height={200}
+								width={200}
+							/>
+							<div className='mt-2'>
+								<Label htmlFor='phone' className='text-sm'>スマホの方はこちら</Label>
+								<a href="https://lin.ee/lIZtWOv" className='flex h-12 justify-center' id="phone" target="_blank">
+									<img src="https://scdn.line-apps.com/n/line_add_friends/btn/ja.png" alt="友だち追加" height="12"/>
+								</a>
+							</div>
+						</div>
+						<div className="order-1 h-full pt-3 sm:pl-3 sm:order-2 mb-4 sm:mb-0">
+							<p className='text-sm font-bold mb-2 self-start'>友だち追加後、認証コードを<br/>LINE Botに送信してください</p>
+							<div>
+								<Label htmlFor="auth-code" className="mb-2">認証コード</Label>
+								<div className="flex items-center justify-end space-x-2">
+									<span className="font-bold text-3xl" id="auth-code">{authCode}</span>
+									<CopyButton textToCopy={String(authCode)} />
+								</div>
+							</div>
+						</div>
+					</div>
+				</DialogContent>
+			</Dialog>
+		</div>
+	);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1530,9 +1530,9 @@ camelcase-css@^2.0.1:
   integrity sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==
 
 caniuse-lite@^1.0.30001579, caniuse-lite@^1.0.30001587, caniuse-lite@^1.0.30001599, caniuse-lite@^1.0.30001640:
-  version "1.0.30001666"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001666.tgz"
-  integrity sha512-gD14ICmoV5ZZM1OdzPWmpx+q4GyefaK06zi8hmfHV5xe4/2nOQX3+Dw5o+fSqOws2xVwL9j+anOPFwHzdEdV4g==
+  version "1.0.30001680"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001680.tgz"
+  integrity sha512-rPQy70G6AGUMnbwS1z6Xg+RkHYPAi18ihs47GH0jcxIG7wArmPgY3XbS2sRdBbxJljp3thdT8BIqv9ccCypiPA==
 
 chalk@^4.0.0:
   version "4.1.2"


### PR DESCRIPTION
## 概要
LINE Botを友だち追加する機能を追加しました．


## 変更点
- ホームにLINE Botの登録ボタン追加
- 友だち追加用QRコード&認証コードのモーダル追加
- 認証コードをDBに保存するリクエスト追加


## 影響範囲
- ホームのボタン
- ローカルストレージ


## 動作要件
- [ ] 各自のLINEアカウントが必要


## テスト
- ホームページのLINE友だち追加ボタン押下
- QRコードから友だち追加
- 友だち追加後，認証コードをLINE Botへ送信
- 認証されると次の18時からシフトに入っている場合，通知が届く


## 関連Issue
- 関連Issue: #32 


## 補足
どのプロバイダからも使える機能にした．
LINEをやっていない人は使えない．